### PR TITLE
Raise an IOError if connection to socket fails.

### DIFF
--- a/pyoo.py
+++ b/pyoo.py
@@ -1785,6 +1785,11 @@ def _get_connection_url(hostname, port, pipe=None):
         conn = 'socket,host=%s,port=%d' % (hostname, port)
     return 'uno:%s;urp;StarOffice.ComponentContext' % conn
 
+def _get_remote_context(resolver, url):
+    try:
+        return resolver.resolve(url)
+    except _NoConnectException:
+        raise IOError(resolver, url)
 
 class Desktop(_UnoProxy):
     """
@@ -1802,7 +1807,7 @@ class Desktop(_UnoProxy):
         url = _get_connection_url(hostname, port, pipe)
         local_context = uno.getComponentContext()
         resolver = local_context.getServiceManager().createInstanceWithContext('com.sun.star.bridge.UnoUrlResolver', local_context)
-        remote_context = resolver.resolve(url)
+        remote_context = _get_remote_context(resolver, url)
         desktop = remote_context.getServiceManager().createInstanceWithContext("com.sun.star.frame.Desktop", remote_context)
         super(Desktop, self).__init__(desktop)
 


### PR DESCRIPTION
Following the statement "We try to catch them and re-throw Python standard exceptions." from the beginning of the file, it makes sense to raise some standard exception when no connection to the socket can be established. The standard python exception that fits best (imo) is IOError as this is also the parent of socket.error.

Note: It might make more sense to raise a socket.error exception instead but that would require importing socket.

Note #2: I didn't write a test for this case since I see no tests related to raising exceptions in the test suit (those could of course be added).