### PR TITLE
save(): allow saving in-place

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -293,6 +293,7 @@ Saving documents
 Spreadsheet documents can be saved using save method: ::
 
     >>> doc.save('example.xlsx', pyoo.FILTER_EXCEL_2007)
+    >>> # doc.save()
 
 And finally do not forget to close the document: ::
 

--- a/pyoo.py
+++ b/pyoo.py
@@ -1662,15 +1662,25 @@ class SpreadsheetDocument(_UnoProxy):
     Spreadsheet document.
     """
 
-    def save(self, path, filter_name=None):
+    def save(self, path=None, filter_name=None):
         """
         Saves this document to a local file system.
+
+        The optional first argument defaults to the document's path.
 
         Accept optional second  argument which defines type of
         the saved file. Use one of FILTER_* constants or see list of
         available filters at http://wakka.net/archives/7 or
         http://www.oooforum.org/forum/viewtopic.phtml?t=71294.
         """
+
+        if path is None:
+            try:
+                self._target.store()
+            except _IOException as e:
+                raise IOError(e.Message)
+            return
+
         # UNO requires absolute paths
         url = uno.systemPathToFileUrl(os.path.abspath(path))
         if filter_name:


### PR DESCRIPTION
So far, the save() method implements the "save as" GUI command.
Implement the "save" GUI command (saving an opened file in-place): this
is called when path is None (omitted) for the save() method.