### PR TITLE
provide calc pdf export module constant

### DIFF
--- a/pyoo.py
+++ b/pyoo.py
@@ -19,6 +19,8 @@ import uno
 
 # Filters used when saving document.
 FILTER_PDF_EXPORT = 'writer_pdf_Export'
+FILTER_WRITER_PDF_EXPORT = 'writer_pdf_Export'
+FILTER_CALC_PDF_EXPORT = 'calc_pdf_Export'
 FILTER_EXCEL_97 = 'MS Excel 97'
 FILTER_EXCEL_2007 = 'Calc MS Excel 2007 XML'
 


### PR DESCRIPTION
pyoo provides FILTER_PDF_EXPORT which users may mistake as being the
(non-existing) general PDF export filter, whereas in fact it is the
writer export filter, which results in an "SfxBaseModel error" 0x81a
when it is used for anything else but writer documents.

Provide FILTER_WRITER_PDF_EXPORT and FILTER_CALC_PDF_EXPORT so that the
two most used export filters are there, and their sheer presence under
these names alerts the user to use the right one (or look at their
value, and infer what to use for "math", "impress" etc.).

FILTER_PDF_EXPORT could be deprecated but is left in for compatibility
reasons for now.